### PR TITLE
Optimize parsing for heald_labview.py

### DIFF
--- a/aimm_adapters/heald_labview.py
+++ b/aimm_adapters/heald_labview.py
@@ -113,15 +113,9 @@ def parse_heald_labview(file):
                 # with a specific format
                 if parsing_case == ParsingCase.column:
                     line = line.replace("*", " ")
-                    line = line.replace("Mono Energy (alt)", "Mono_Energy_(alt)")
-                    line = line.replace("Scaler preset time", "Scaler_preset_time")
-                    line = line.replace("ID Gap", "ID_Gap")
-                    line = line.replace("XMAP4:DT Corr I0", "XMAP4:DT_Corr_I0")
                     line = line.replace("tempeXMAP4", "tempe        XMAP4")
 
-                    line = line.replace("XMAP12:DT Corr I0", "XMAP12:DT_Corr_I0")
-                    line = " ".join(line.split())  # Remove unwanted white spaces
-                    headers = line.split()
+                    headers = [term for term in line.split("  ") if term]
                     meta_dict["Columns"] = headers
                     parsing_case = 0
                 elif parsing_case == ParsingCase.user:


### PR DESCRIPTION
Some column names include underscore lines to separate words, others include whitespace. This inconsistency creates a problem when the spacing between columns is done by whitespaces instead of tab spaces. I added a method that considers one white space as the separation between words in a column name; more spaces indicate a separation between columns. This approach is compatible with the current data sets that we have obtained so far.