### PR TITLE
Changed column names to a more accurate name following XDI standard of column description

### DIFF
--- a/aimm_adapters/heald_labview.py
+++ b/aimm_adapters/heald_labview.py
@@ -328,9 +328,8 @@ def normalize_dataframe(df):
     keywords = {
         "time": ["Scaler preset time", "None"],
         "i0": ["I0", "IO", "I-0"],
-        "it": ["IT", "I1", "I", "It", "Trans"],
-        "ir": ["Iref", "IRef", "I2", "IR", "IREF", "DiodeRef", "Cal(Iref)", "Ref"],
-        "if": [
+        "itrans": ["IT", "I1", "I", "It", "Trans"],
+        "ifluor": [
             "Ifluor",
             "IF",
             "If",
@@ -341,6 +340,7 @@ def normalize_dataframe(df):
             "Cal_diode",
             "Canberra",
         ],
+        "irefer": ["Iref", "IRef", "I2", "IR", "IREF", "DiodeRef", "Cal(Iref)", "Ref"],
     }
     column_names = set(df.columns.values.tolist())
     norm_df = None


### PR DESCRIPTION
Previously, the information of the detector namespace was being used for the column names. The website for XDI standards provides another section with more accurate names for the columns which were used for this update.